### PR TITLE
chore: Update hardhat and brownie configurations

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,7 +1,0 @@
-dependencies:
-  - smartcontractkit/chainlink-brownie-contracts@1.1.1
-
-compiler:
-  solc:
-    remappings:
-     -"@chainlink=smartcontractkit/chainlink-brownie-contracts@1.1.1"

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,23 @@
 require("@nomicfoundation/hardhat-toolbox");
+require("@nomiclabs/hardhat-ethers");
 
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
-  solidity: "0.8.24",
+  defaultNetwork: "hardhat",
+  networks: {
+    hardhat: {},
+    myQuickNode: {
+      url: process.env.quickNodeKey,
+      accounts: [process.env.privateKey],    
+    },
+  },
+  solidity: {
+    version: "0.8.24",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200
+      }
+    }
+  },
 };

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,17 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+    //Get the chairity contract to deploy
+    const Chairity = await ethers.getContractFactory("Chairity");
+
+    //start deployment
+    const chainrity = await Chairity.deploy();
+    console.log("Chairity deployed to:", chairity.address);
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });


### PR DESCRIPTION
This commit updates the hardhat and brownie configurations to include necessary dependencies and settings. The hardhat configuration now includes the `@nomiclabs/hardhat-ethers` plugin, and the brownie configuration removes the `smartcontractkit/chainlink-brownie-contracts@1.1.1` dependency and remapping.